### PR TITLE
docs(readme): Fix The İnstall Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Install
 ```sh
-$ npm i discord-buttons
+npm i discord-buttons
 ```
 ## Setup
 ```js


### PR DESCRIPTION
The install command has $ front of it it's not copy-paste friendly